### PR TITLE
Make FloatOrd "transparent"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "float-ord"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Michael Howell <michael@notriddle.com>"]
 description = "A total ordering for floating-point numbers"
 keywords = ["floats", "sort", "compare"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use core::mem::transmute;
 /// A wrapper for floats, that implements total equality and ordering
 /// and hashing.
 #[derive(Clone, Copy, Debug)]
+#[transparent]
 pub struct FloatOrd<T>(pub T);
 
 macro_rules! float_ord_impl {


### PR DESCRIPTION
The simplest patch possible :)

P.S. Since adding `#[transparent]` isn't a breaking change, I bump only the patch version.

Solves #13